### PR TITLE
fix: add marked.min.js to export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "default": "./lib/marked.cjs"
     },
     "./bin/marked": "./bin/marked.js",
+    "./marked.min.js": "./marked.min.js",
     "./package.json": "./package.json"
   },
   "repository": "git://github.com/markedjs/marked.git",


### PR DESCRIPTION
This change adds the minified js to the package's export conditions.  This will allow projects using PnP to have access to the script during build time.
